### PR TITLE
Leaderboard data logging

### DIFF
--- a/omega/protocol.py
+++ b/omega/protocol.py
@@ -52,11 +52,13 @@ class Videos(BaseModel):
     - query: the input query for which to find relevant videos
     - num_videos: the number of videos to return
     - video_metadata: a list of video metadata objects
+    - hotkey: the hotkey for the responding miner
     """
 
     query: str
     num_videos: int
     video_metadata: typing.Optional[typing.List[VideoMetadata]] = None
+    hotkey: str = None
 
     def deserialize(self) -> typing.List[VideoMetadata]:
         assert self.video_metadata is not None

--- a/src/subnet/utils.py
+++ b/src/subnet/utils.py
@@ -5,8 +5,8 @@ import sys
 
 def iso_timestamp_now() -> str:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
-    iso_now = now.isoformat()
-    return iso_now
+    formatted_now = now.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]  # Truncate microseconds to milliseconds
+    return formatted_now
 
 """
 def log(

--- a/src/subnet/validator/validator.py
+++ b/src/subnet/validator/validator.py
@@ -476,6 +476,7 @@ class VideosValidator(Module):
             if miner_response is None or miner_response.video_metadata is None:
                 log.info(f"Miner {uid} did not answer.")
                 continue
+            miner_response.hotkey = random_modules_info[uid][1]
             working_miner_uids.append(uid)
             finished_responses.append(miner_response)
         
@@ -667,6 +668,10 @@ class VideosValidator(Module):
     ) -> torch.FloatTensor:
         
         try:
+            # return minimum score if no videos were found in video_metadata
+            if len(videos.video_metadata) == 0:
+                return MIN_SCORE
+
             # check video_ids for fake videos
             if any(not video_utils.is_valid_id(video.video_id) for video in videos.video_metadata):
                 return FAKE_VIDEO_PUNISHMENT
@@ -784,8 +789,9 @@ class VideosValidator(Module):
                 score: {score}
             ''')
 
-            # Upload our final results to API endpoint for index and dataset insertion
-            upload_result = await self.upload_video_metadata(metadata, description_relevance_scores, query_relevance_scores, videos.query)
+            # Upload our final results to API endpoint for index and dataset insertion. Include leaderboard statistics
+            miner_hotkey = videos.hotkey
+            upload_result = await self.upload_video_metadata(metadata, description_relevance_scores, query_relevance_scores, videos.query, novelty_score, score, miner_hotkey)
             if upload_result:
                 log.info("Uploading of video metadata successful.")
             else:
@@ -814,7 +820,16 @@ class VideosValidator(Module):
         return rewards
         
     
-    async def upload_video_metadata(self, metadata: List[VideoMetadata], description_relevance_scores: List[float], query_relevance_scores: List[float], query: str) -> bool:
+    async def upload_video_metadata(
+        self, 
+        metadata: List[VideoMetadata], 
+        description_relevance_scores: List[float], 
+        query_relevance_scores: List[float], 
+        query: str,
+        novelty_score: float, 
+        score: float, 
+        miner_hotkey: str
+    ) -> bool:
         """
         Queries the validator api to get novelty scores for supplied videos. 
         Returns a list of float novelty scores for each video after deduplicating.
@@ -834,7 +849,10 @@ class VideosValidator(Module):
                     "metadata": serialized_metadata,
                     "description_relevance_scores": description_relevance_scores,
                     "query_relevance_scores": query_relevance_scores,
-                    "topic_query": query
+                    "topic_query": query,
+                    "novelty_score": novelty_score,
+                    "total_score": score,
+                    "miner_hotkey": miner_hotkey
                 }
 
                 async with session.post(
@@ -967,7 +985,7 @@ class VideosValidator(Module):
                 if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(
                     days=1
                 ):
-                    bt.logging.info(
+                    log.info(
                         "Current wandb run is more than 1 day old. Starting a new run."
                     )
                     self.wandb_run.finish()


### PR DESCRIPTION
adding in leaderboard logic. passing more response data from miners to API for consumption. updating logging timestamp format.

Requires the bittensor repo PR to be complete to actually log data, but it will work with current versions of the validator API.
https://github.com/omegalabsinc/omegalabs-bittensor-subnet/pull/17